### PR TITLE
Fix refresh intervals and storage key imports

### DIFF
--- a/lib/home/home.dart
+++ b/lib/home/home.dart
@@ -23,7 +23,7 @@ import '../utils/utils.dart';
 import 'package:get_it/get_it.dart';
 import 'package:intl/intl.dart';
 import 'package:mobx/mobx.dart';
-import 'package:mobx/version.dart' as StorageKeys;
+import '../resources/storage_keys.dart';
 import 'package:provider/provider.dart';
 
 const bool isDevMode = String.fromEnvironment('MODE') == 'debug';

--- a/lib/home/model/background_settings.dart
+++ b/lib/home/model/background_settings.dart
@@ -46,8 +46,8 @@ enum BackgroundRefreshRate {
   newTab('Every New Tab', Duration(days: 365)),
   minute('Every Minute', Duration(minutes: 1)),
   fiveMinute('Every 5 Minute', Duration(minutes: 5)),
-  fifteenMinute('Every 15 Minute', Duration(minutes: 5)),
-  thirtyMinute('Every 30 Minute', Duration(minutes: 5)),
+  fifteenMinute('Every 15 Minute', Duration(minutes: 15)),
+  thirtyMinute('Every 30 Minute', Duration(minutes: 30)),
   hour('Every hour', Duration(hours: 1)),
   daily('Every Day', Duration(days: 1)),
   weekly('Every Week', Duration(days: 7));

--- a/lib/settings/settings_panel.dart
+++ b/lib/settings/settings_panel.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_mobx/version.dart' as StorageKeys;
+import '../resources/storage_keys.dart';
 import '../home/background_store.dart';
 import '../home/home_store.dart';
 import '../home/model/background_settings.dart';


### PR DESCRIPTION
## Summary
- correct BackgroundRefreshRate durations
- use local StorageKeys instead of MobX versions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa4c76364832b8e4fa73a50738f8f